### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/src/components/landing-page/form-controller.ts
+++ b/src/components/landing-page/form-controller.ts
@@ -4,7 +4,7 @@
  * Consolidates form-state and interaction-controller responsibilities.
  */
 
-import { getModeConfig, MODE_ORDER } from '@core/config/mode-config';
+import { getModeConfig, isValidMode, MODE_ORDER } from '@core/config/mode-config';
 import { convertWallClockToAbsolute, createNextOccurrence } from '@core/time/wall-clock-conversion';
 import type { CountdownConfig, CountdownMode, ThemeId } from '@core/types';
 import {
@@ -200,11 +200,8 @@ export function createFormController(
   return {
     // State management methods
     initializeForm(config: Partial<CountdownConfig> | undefined, state: LandingPageFormState): void {
-      // Mode - ensure valid mode type for radio selection
-      const requestedMode = state.mode;
-      const safeMode: CountdownMode = MODE_ORDER.includes(requestedMode as CountdownMode)
-        ? (requestedMode as CountdownMode)
-        : MODE_ORDER[0];
+      // Mode - validate against known modes to prevent prototype pollution
+      const safeMode: CountdownMode = isValidMode(state.mode) ? state.mode : MODE_ORDER[0];
       elements.modeRadios[safeMode].checked = true;
       this.toggleMode(safeMode, state);
 

--- a/src/core/config/mode-config.ts
+++ b/src/core/config/mode-config.ts
@@ -129,6 +129,15 @@ export function worldMapAvailableForMode(mode: CountdownMode, userConfig?: boole
 /** Modes in display order (landing page). @public */
 export const MODE_ORDER: readonly CountdownMode[] = ['wall-clock', 'absolute', 'timer'] as const;
 
+/**
+ * Type guard to validate a value is a known CountdownMode.
+ * Prevents prototype pollution by ensuring only literal mode strings are accepted.
+ * @public
+ */
+export function isValidMode(value: unknown): value is CountdownMode {
+  return MODE_ORDER.includes(value as CountdownMode);
+}
+
 /** Get all mode configs in display order for UI iteration. @public */
 export function getAllModeConfigs(): ReadonlyArray<{ mode: CountdownMode; config: ModeConfig }> {
   return MODE_ORDER.map(mode => ({ mode, config: MODE_CONFIG[mode] }));


### PR DESCRIPTION
Potential fix for [https://github.com/chrisreddington/timestamp/security/code-scanning/1](https://github.com/chrisreddington/timestamp/security/code-scanning/1)

General approach: prevent untrusted strings that might be `__proto__`, `prototype`, or `constructor` (or otherwise invalid) from being used as dynamic property names on plain objects. For this case, we can sanitize or validate `state.mode` before using it as an index into `elements.modeRadios`, ensuring it is one of the legitimate countdown modes defined by `MODE_ORDER`, and falling back to a safe default if not.

Concrete fix for this codebase:

- In `src/components/landing-page/form-controller.ts`, inside `initializeForm`, instead of directly using `state.mode`, derive a safe `mode` by checking whether `state.mode` is one of the allowed modes in `MODE_ORDER`. If not, fall back to a known-safe default mode (e.g., `'wall-clock'`, or the first entry in `MODE_ORDER`).
- Use this validated `safeMode` both for indexing `elements.modeRadios` and when calling `this.toggleMode` and `this.updateStartButtonLabel`. This keeps behavior unchanged for valid values while preventing any unexpected or malicious string (including `__proto__`) from being used as a key.
- This change stays entirely within the provided snippet; it doesn’t alter imports or other modules.

Concretely:

- Modify lines around 202–207 in `initializeForm` to:
  - Compute `const safeMode = MODE_ORDER.includes(state.mode) ? state.mode : MODE_ORDER[0];`
  - Use `safeMode` instead of `mode` for radio selection and toggling.

No additional methods or imports are needed; `MODE_ORDER` is already imported at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
