### PR TITLE
Fix apostrophe rendering in celebration messages

### DIFF
--- a/src/themes/contribution-graph/utils/canvas/celebration.ts
+++ b/src/themes/contribution-graph/utils/canvas/celebration.ts
@@ -44,9 +44,20 @@ function celebrationLineWidth(text: string): number {
 
 /**
  * Clean message text (uppercase, alphanumeric + common punctuation).
+ * Also decodes common HTML entities to handle cases where they might be present.
  */
 function cleanMessage(message: string): string {
-  return message
+  // First decode common HTML entities that might have leaked in
+  const decoded = message
+    .replace(/&#39;/g, "'")  // Apostrophe
+    .replace(/&apos;/g, "'") // Alternative apostrophe entity
+    .replace(/&#x27;/g, "'") // Hex apostrophe entity
+    .replace(/&quot;/g, '"') // Quote
+    .replace(/&amp;/g, '&')  // Ampersand
+    .replace(/&lt;/g, '<')   // Less than
+    .replace(/&gt;/g, '>');  // Greater than
+
+  return decoded
     .toUpperCase()
     .replace(/[^A-Z0-9 .,!?'-]/g, '')
     .trim();


### PR DESCRIPTION
This was me basically ONLY asking Copilot to fix. I'm gonna assign this to Copilot to see if this actually works the way it thinks it does. 

Fixes issue where HTML entities (like &#39;) in celebration messages 'TIME39S UP!' in the contribution graph theme.

The cleanMessage function now decodes common HTML entities before applying the character filter, ensuring messages display correctly even if HTML-encoded text makes it through.

This is defensive programming to handle edge cases where HTML entities might leak into what should be plain text.