### PR TITLE
ci: add Dependabot auto-merge for low-risk updates and align cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,10 @@ updates:
     # This helps avoid updates to broken/yanked versions that may be pulled quickly
     # Learn more: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown
     cooldown:
-      default-days: 3
-      semver-major-days: 7
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 3
     # Grouped updates: Combine related dependencies into single PRs
     # This reduces review overhead and keeps related updates atomic
     # Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
@@ -97,6 +99,9 @@ updates:
       time: "09:00"
       timezone: "Europe/London"
     open-pull-requests-limit: 5
+    # Cooldown gives newly released actions time to stabilize before updating
+    cooldown:
+      default-days: 7
     groups:
       # Group all GitHub Actions updates together
       # Actions typically have coordinated releases and low breaking change risk
@@ -121,6 +126,9 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    # Cooldown gives newly released devcontainer features time to stabilize
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "devcontainer"
       include: "scope"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,49 @@
+# Dependabot Auto-Merge
+# Automatically approves and enables auto-merge for low-risk Dependabot updates
+# (patch and minor version bumps). Major updates are intentionally excluded so a
+# human can review potentially breaking changes.
+#
+# Safety: `gh pr merge --auto` only completes once the branch ruleset's required
+# status checks pass, so a low-risk update is merged only when CI is green.
+# Documentation: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+# Least-privilege permissions: approve PRs and enable auto-merge
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-automerge:
+    runs-on: ubuntu-latest
+    # Only act on PRs opened by Dependabot
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      # Fetch metadata about the update (semver bump type, dependency names, etc.)
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Approve only patch and minor updates (low risk)
+      - name: Auto-approve patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Enable auto-merge so the PR squash-merges once required checks pass
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -47,10 +47,13 @@ jobs:
           # Adjust this to 'critical' or 'high' if you want to allow lower severity issues
           fail-on-severity: low
 
-          # Allow only permissive licenses compatible with MIT
+          # Allow permissive licenses compatible with MIT, plus MPL-2.0
+          # MPL-2.0 is a weak (file-level) copyleft license used by axe-core /
+          # @axe-core/playwright, which are dev-only accessibility testing tools
+          # and are not redistributed as part of the app bundle.
           # Uses allow-list instead of deprecated deny-list for better maintainability
           # See: https://github.com/actions/dependency-review-action/issues/997
-          allow-licenses: MIT, ISC, Apache-2.0, BSD-2-Clause, BSD-3-Clause, 0BSD, CC0-1.0, Unlicense, Python-2.0
+          allow-licenses: MIT, ISC, Apache-2.0, BSD-2-Clause, BSD-3-Clause, 0BSD, CC0-1.0, Unlicense, Python-2.0, MPL-2.0
 
           # Comment on PR with review results (summary of vulnerabilities and license issues)
           comment-summary-in-pr: always


### PR DESCRIPTION
## Summary

Configures automated merging of low-risk Dependabot updates for `timestamp`, mirroring the pattern already in use across `chrisreddington/trend-radar` and the `validate-*` repos.

### Changes

**1. New workflow — `.github/workflows/dependabot-automerge.yml`**
- Auto-approves and enables `--auto --squash` merge for **patch and minor** updates only.
- **Major updates are intentionally excluded** so a human reviews potentially breaking changes.
- Uses `dependabot/fetch-metadata` pinned to a full commit SHA (`v3.1.0`), with least-privilege `contents: write` / `pull-requests: write` permissions — identical to the reference repos.

**2. `.github/dependabot.yml` — aligned cooldowns across all configured ecosystems**
| Ecosystem | Cooldown |
|---|---|
| npm | default 7d · major 14d · minor 3d · patch 3d |
| github-actions | default 7d |
| devcontainers | default 7d |

(Previously only npm had a partial cooldown of default 3d / major 7d; github-actions and devcontainers had none.)

**3. `.github/workflows/dependency-review.yml` — allow `MPL-2.0`**
- `axe-core` / `@axe-core/playwright` (existing dev-only accessibility testing tools) are MPL-2.0, which previously failed the dependency-review license check on most npm PRs. MPL-2.0 is a weak, file-level copyleft license and these packages aren't redistributed in the app bundle, so it's added to the `allow-licenses` list.

**4. Branch ruleset — required status check (applied via API, not in this diff)**
- Added `build` as a **required status check** on `main`. This is what makes `gh pr merge --auto` *safe*: a low-risk update only merges once CI is green.

### Why only `build` is required (not `validate-themes` / `smoke-test-generator`)
Those two workflows are **path-filtered** (they run only when theme/generator files change). A required status check that never runs leaves a PR permanently blocked — which would block every Dependabot npm PR and defeat auto-merge entirely. `build` runs on every PR to `main`, so it's the correct universal gate. CodeQL remains enforced via the existing `code_scanning` rule.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>