### PR TITLE
ci(deps): group stryker and stylelint toolchains in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,28 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Stryker mutation testing toolchain
+      # core, vitest-runner and typescript-checker share a locked peer
+      # dependency on the same version, so they must update together —
+      # major updates are included so the whole toolchain moves atomically.
+      stryker:
+        patterns:
+          - "@stryker-mutator/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      # Stylelint toolchain
+      # stylelint and its shared configs (config-standard, config-standard-scss)
+      # are peer-locked to a matching stylelint major, so they must update
+      # together — major updates are included so the cluster moves atomically.
+      stylelint:
+        patterns:
+          - "stylelint*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
     # Major updates kept separate for careful review
     # Semantic versioning major updates may contain breaking changes
     # Customize commit messages for better changelog integration


### PR DESCRIPTION
## Summary

Adds two Dependabot groups so peer-locked toolchains update **atomically** instead of as individual PRs that can't install.

### Problem
Several open Dependabot PRs fail their `build` check purely due to **`ERESOLVE` peer-dependency conflicts** — not code breakage:
- **Stryker:** `@stryker-mutator/vitest-runner` (#40) and `typescript-checker` (#41) require `@stryker-mutator/core` at the same version; bumping one without the others conflicts.
- **Stylelint:** `stylelint-config-standard` (#32), `stylelint-config-standard-scss` (#34) and `stylelint` (#39) are peer-locked to a matching `stylelint` major; bumping one without the others conflicts.

### Change
New `npm` groups (each includes `major` so the whole cluster moves together):
| Group | Patterns |
|---|---|
| `stryker` | `@stryker-mutator/*` |
| `stylelint` | `stylelint*` |

Once merged, Dependabot will supersede the five individual PRs above with two grouped PRs that install cleanly and pass `build`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>