### PR TITLE
fix(e2e): unblock Pages deploy by fixing fullscreen resize test

### DIFF
--- a/e2e/fullscreen-mode.spec.ts
+++ b/e2e/fullscreen-mode.spec.ts
@@ -227,7 +227,17 @@ test.describe('Fullscreen Mode - Edge Cases', () => {
     await enterFullscreen(page);
     await waitForFullscreenState(page, true);
 
-    await page.setViewportSize({ width: 1024, height: 1440 });
+    // Chromium refuses Browser.setWindowBounds (used by setViewportSize) while
+    // the window is in real fullscreen, so emulate the viewport change via CDP
+    // instead. This updates innerWidth/innerHeight (and fires resize) without
+    // touching the OS window, exercising the app's resize handling in fullscreen.
+    const client = await page.context().newCDPSession(page);
+    await client.send('Emulation.setDeviceMetricsOverride', {
+      width: 1024,
+      height: 1440,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
     await page.waitForFunction(
       () => window.innerWidth === 1024 && window.innerHeight === 1440,
       { timeout: 2000 }


### PR DESCRIPTION
## Problem

The GitHub Pages `deploy` job has been silently skipped on every `main` run because it depends on the full `e2e` suite passing, and one E2E test fails deterministically:

```
e2e/fullscreen-mode.spec.ts:222 › handles window resize while in fullscreen
Protocol error (Browser.setWindowBounds): To resize minimized/maximized/fullscreen
window, restore it to normal state first.
```

After Playwright was bumped to `^1.60.0` (testing group update), the newer Chromium refuses `Browser.setWindowBounds` — which backs `page.setViewportSize` — while the window is in **real** fullscreen. The test enters fullscreen and then calls `setViewportSize`, so it throws every run. No deploys have shipped since that bump merged.

## Fix

Emulate the viewport change via CDP `Emulation.setDeviceMetricsOverride` instead of `setViewportSize`. This updates `window.innerWidth/innerHeight` (and fires `resize`) **without** touching the OS window, so it works while fullscreen and still exercises the app's resize handling. CDP is already an established pattern in this repo (`e2e/performance-profiling.spec.ts`).

## Validation

- `npx playwright test e2e/fullscreen-mode.spec.ts --project=chromium` → **20/20 passed** locally.
- Test intent preserved: still asserts `document.fullscreenElement !== null` and the countdown stays visible after the resize.

Once green, this unblocks the `deploy` job so the site (including recent theme changes) ships again.