### PR TITLE
fix(pwa): stop the "new version available" banner from getting stuck

### DIFF
--- a/src/app/pwa/update-manager.ts
+++ b/src/app/pwa/update-manager.ts
@@ -5,42 +5,38 @@ import type { UpdateCheckConfig } from './types';
 
 const DEFAULT_CHECK_INTERVAL = 60 * 1000;
 const MIN_CHECK_INTERVAL = 30 * 1000;
-/** Fallback delay for dev environments when controllerchange may not fire */
-const DEV_CONTROLLER_CHANGE_FALLBACK_DELAY_MS = 100;
+/** Fallback delay before forcing a reload if `controllerchange` never fires */
+const CONTROLLER_CHANGE_FALLBACK_DELAY_MS = 3000;
 
 /**
- * Activates a waiting service worker and reloads when it takes control.
+ * Activates a waiting service worker and reloads when it takes control, with a
+ * fallback timeout so the reload happens even if `controllerchange` never fires.
  * @param registration - Service worker registration containing waiting worker
- * @param options - Optional config with dev reload delay
+ * @param options - Optional override for the reload fallback delay
  * @internal
  */
 function activateWaitingServiceWorker(
   registration: ServiceWorkerRegistration,
-  options: { devReloadDelayMs?: number } = {}
+  options: { reloadFallbackDelayMs?: number } = {}
 ): void {
   const waitingWorker = registration.waiting;
   if (!waitingWorker) return;
 
   let hasReloaded = false;
 
-  const handleControllerChange = (): void => {
+  const reload = (): void => {
     if (hasReloaded) return;
     hasReloaded = true;
-    navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
+    clearTimeout(fallbackTimer);
+    navigator.serviceWorker.removeEventListener('controllerchange', reload);
     window.location.reload();
   };
 
   waitingWorker.postMessage({ type: 'SKIP_WAITING' });
-  navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange);
+  navigator.serviceWorker.addEventListener('controllerchange', reload);
 
-  if (import.meta.env.DEV && options.devReloadDelayMs !== undefined) {
-    setTimeout(() => {
-      if (hasReloaded) return;
-      hasReloaded = true;
-      navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
-      window.location.reload();
-    }, options.devReloadDelayMs);
-  }
+  const fallbackDelay = options.reloadFallbackDelayMs ?? CONTROLLER_CHANGE_FALLBACK_DELAY_MS;
+  const fallbackTimer = setTimeout(reload, fallbackDelay);
 }
 
 /** Controller for managing service worker updates. */
@@ -111,9 +107,7 @@ export function createUpdateManager(config: UpdateCheckConfig = {}): UpdateManag
   function applyUpdate(): void {
     if (!registration?.waiting || isApplyingUpdate) return;
     isApplyingUpdate = true;
-    activateWaitingServiceWorker(registration, {
-      devReloadDelayMs: DEV_CONTROLLER_CHANGE_FALLBACK_DELAY_MS,
-    });
+    activateWaitingServiceWorker(registration);
   }
 
   async function checkForUpdate(): Promise<boolean> {

--- a/src/app/pwa/update-prompt.test.ts
+++ b/src/app/pwa/update-prompt.test.ts
@@ -158,6 +158,67 @@ describe('UpdatePrompt', () => {
     }
   });
 
+  it('should reload immediately on refresh when no worker is waiting', async () => {
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadMock },
+      writable: true,
+    });
+
+    // Banner is shown (e.g. via the pwa:update-available event) but the waiting
+    // worker has since activated, so registration.waiting is null at click time.
+    mockRegistration.waiting = mockServiceWorker;
+    await initAndAttach();
+    await waitForVisibility(true);
+    mockRegistration.waiting = null;
+
+    const refreshButton = updatePrompt.getElement().querySelector('.update-prompt-refresh-btn') as HTMLButtonElement;
+    refreshButton.click();
+
+    expect(mockServiceWorker.postMessage).not.toHaveBeenCalled();
+    expect(reloadMock).toHaveBeenCalled();
+  });
+
+  it('should hide the banner immediately when refresh is clicked', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { reload: vi.fn() },
+      writable: true,
+    });
+
+    mockRegistration.waiting = mockServiceWorker;
+    const element = await initAndAttach();
+    await waitForVisibility(true);
+
+    const refreshButton = element.querySelector('.update-prompt-refresh-btn') as HTMLButtonElement;
+    refreshButton.click();
+
+    await waitForVisibility(false);
+  });
+
+  it('should reload via fallback timer if controllerchange never fires', async () => {
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadMock },
+      writable: true,
+    });
+
+    mockRegistration.waiting = mockServiceWorker;
+    await initAndAttach();
+    await waitForVisibility(true);
+
+    vi.useFakeTimers();
+    const refreshButton = updatePrompt.getElement().querySelector('.update-prompt-refresh-btn') as HTMLButtonElement;
+    refreshButton.click();
+
+    expect(mockServiceWorker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    // controllerchange is never dispatched; the fallback timer must still reload.
+    expect(reloadMock).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(3000);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
   it('should hide prompt on dismiss button click', async () => {
     mockRegistration.waiting = mockServiceWorker;
     const element = await initAndAttach();

--- a/src/app/pwa/update-prompt.ts
+++ b/src/app/pwa/update-prompt.ts
@@ -8,40 +8,42 @@ const DISMISSED_KEY = 'pwa-update-dismissed';
 const DISMISS_DURATION_MS = 2 * 60 * 60 * 1000;
 const VISIBLE_CLASS = 'update-prompt-container--visible';
 const NO_ANIMATION_CLASS = 'update-prompt-container--no-animation';
-const DEV_CONTROLLER_CHANGE_FALLBACK_DELAY_MS = 100;
+/**
+ * Fallback delay before forcing a reload if `controllerchange` never fires.
+ * Some scenarios (multiple tabs/clients, a worker that already activated) won't
+ * emit `controllerchange` for this client, which would otherwise leave the
+ * banner stuck on screen forever. The reload happens regardless after this.
+ */
+const CONTROLLER_CHANGE_FALLBACK_DELAY_MS = 3000;
 
 /**
- * Activates a waiting SW and reloads when it takes control.
+ * Activates a waiting SW and reloads when it takes control, with a fallback
+ * timeout so the reload always happens even if `controllerchange` never fires.
  * @param registration - Service worker registration
- * @param options - Optional config with dev reload delay
+ * @param options - Optional override for the reload fallback delay
  */
 function activateWaitingServiceWorker(
   registration: ServiceWorkerRegistration,
-  options: { devReloadDelayMs?: number } = {}
+  options: { reloadFallbackDelayMs?: number } = {}
 ): void {
   const waitingWorker = registration.waiting;
   if (!waitingWorker) return;
 
   let hasReloaded = false;
 
-  const handleControllerChange = (): void => {
+  const reload = (): void => {
     if (hasReloaded) return;
     hasReloaded = true;
-    navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
+    clearTimeout(fallbackTimer);
+    navigator.serviceWorker.removeEventListener('controllerchange', reload);
     window.location.reload();
   };
 
   waitingWorker.postMessage({ type: 'SKIP_WAITING' });
-  navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange);
+  navigator.serviceWorker.addEventListener('controllerchange', reload);
 
-  if (import.meta.env.DEV && options.devReloadDelayMs !== undefined) {
-    setTimeout(() => {
-      if (hasReloaded) return;
-      hasReloaded = true;
-      navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
-      window.location.reload();
-    }, options.devReloadDelayMs);
-  }
+  const fallbackDelay = options.reloadFallbackDelayMs ?? CONTROLLER_CHANGE_FALLBACK_DELAY_MS;
+  const fallbackTimer = setTimeout(reload, fallbackDelay);
 }
 
 /** Controller for the update prompt component. */
@@ -133,10 +135,14 @@ export function createUpdatePrompt(): UpdatePromptController {
 
   function handleRefresh(): void {
     clearDismissed();
+    // Hide immediately so the banner can't get visually stuck if the reload is delayed.
+    hide();
     if (registration?.waiting) {
-      activateWaitingServiceWorker(registration, {
-        devReloadDelayMs: DEV_CONTROLLER_CHANGE_FALLBACK_DELAY_MS,
-      });
+      activateWaitingServiceWorker(registration);
+    } else {
+      // No waiting worker means the new version likely already activated (e.g. via
+      // another tab/client). Reload to pick it up so the prompt resolves either way.
+      window.location.reload();
     }
   }
 


### PR DESCRIPTION
## Problem

The **"A new version is available! Refresh"** banner could get permanently stuck on screen — clicking **Refresh** sometimes did nothing.

This is a `registerType: 'prompt'` PWA, so the banner appearing on a new deploy is by design. The bug is in how **Refresh** resolves it:

1. `handleRefresh()` posts `SKIP_WAITING` and relies **solely** on a `controllerchange` event to call `window.location.reload()`. The fallback timeout existed but was gated behind `import.meta.env.DEV` — so **production had no fallback**.
2. If `controllerchange` never fires for this client (multiple tabs/clients, or the parallel `update-manager` already swapped the controller), the page never reloads.
3. Once the waiting worker activates, `registration.waiting` becomes `null`. The next Refresh click hits `if (registration?.waiting)` → false → **no-op**, and the banner is never hidden. It stays until a manual hard reload.

## Fix

Make the Refresh action self-healing:

- **Production fallback timer** — always reload after a short delay if `controllerchange` doesn't fire (previously dev-only).
- **Hide immediately on Refresh** so the banner can't get visually stuck if the reload is briefly delayed.
- **No waiting worker → reload directly** to pick up an already-activated version, instead of doing nothing.
- Applied the same robustness to `update-manager`'s duplicate `activateWaitingServiceWorker` helper for parity.

## Validation

- Added 3 unit tests: reload-with-no-waiting-worker, hide-on-refresh, and fallback-timer reload.
- `update-prompt` + `update-manager` suites: **35/35 pass**.
- Full suite: **3053/3053 pass**; typecheck, lint, and production build all clean.