### PR TITLE
Reduce PR artifact storage in CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,8 +79,9 @@ jobs:
           VITE_SITE_URL: ${{ steps.pages.outputs.base_url }}
 
       # Upload build artifact for other jobs to consume
-      # This artifact is used by deploy job
+      # This artifact is used only by the main-branch deploy job.
       - name: Upload build artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: upload
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:


### PR DESCRIPTION
## Summary

Only upload the `dist` build artifact for pushes to `main`.

## Why

This optimises GitHub Actions storage by avoiding deployment-only artifacts on pull request runs. The `dist` artifact is consumed solely by the GitHub Pages deployment job, which runs only on `main`.

## Impact

Pull requests continue to run the existing build and test checks. They no longer upload the deployment-only artifact.

## Validation

- `git diff --check`
- Workflow YAML parsed successfully